### PR TITLE
Workaround corrupt passwords.conf

### DIFF
--- a/TA_runzero_asset_sync/TA_runzero_asset_sync.aob_meta
+++ b/TA_runzero_asset_sync/TA_runzero_asset_sync.aob_meta
@@ -2,7 +2,7 @@
   "basic_builder": {
     "appname": "TA_runzero_asset_sync",
     "friendly_name": "runZero Asset Sync",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "author": "runZero",
     "description": "This application synchronizes a runZero inventory with Splunk, pulling newly-found or updated hosts as configured.",
     "theme": "#65A637",

--- a/TA_runzero_asset_sync/app.manifest
+++ b/TA_runzero_asset_sync/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "TA_runzero_asset_sync",
-      "version": "3.1.1"
+      "version": "3.1.2"
     },
     "author": [
       {

--- a/TA_runzero_asset_sync/appserver/static/js/build/globalConfig.json
+++ b/TA_runzero_asset_sync/appserver/static/js/build/globalConfig.json
@@ -2,7 +2,7 @@
     "meta": {
         "name": "TA_runzero_asset_sync",
         "displayName": "runZero Asset Sync",
-        "version": "3.1.1",
+        "version": "3.1.2",
         "restRoot": "TA_runzero_asset_sync",
         "_uccVersion": "5.39.0",
         "schemaVersion": "0.0.3"

--- a/TA_runzero_asset_sync/bin/TA_runzero_asset_sync/aob_py3/solnlib/credentials.py
+++ b/TA_runzero_asset_sync/bin/TA_runzero_asset_sync/aob_py3/solnlib/credentials.py
@@ -321,7 +321,10 @@ class CredentialManager:
                 clear_password = ""
                 for index in sorted(field_clear.keys()):
                     if field_clear[index] != self.END_MARK:
-                        clear_password += field_clear[index]
+                        # XXX: runZero was here!!!
+                        # runZero modified this code to work with invalid passwords in passwords.conf files
+                        if field_clear[index] != None:
+                            clear_password += field_clear[index]
                     else:
                         break
                 values["clear_password"] = clear_password

--- a/TA_runzero_asset_sync/bin/TA_runzero_asset_sync/aob_py3/splunktaucclib/rest_handler/credentials.py
+++ b/TA_runzero_asset_sync/bin/TA_runzero_asset_sync/aob_py3/splunktaucclib/rest_handler/credentials.py
@@ -308,8 +308,10 @@ class RestCredentials:
         # merge clear passwords to response data
         changed_item_list = []
 
+        # XXX: runZero was here!!!
+        # runZero modified this code to work with invalid passwords in passwords.conf files
         password_dict = {
-            pwd["username"]: json.loads(pwd["clear_password"]) for pwd in passwords
+            pwd["username"]: json.loads(pwd["clear_password"] or '{}') for pwd in passwords
         }
         # existed passwords models: previously has encrypted value
         existing_encrypted_items = [x for x in data if x["name"] in password_dict]

--- a/TA_runzero_asset_sync/default/app.conf
+++ b/TA_runzero_asset_sync/default/app.conf
@@ -6,12 +6,12 @@ state = enabled
 build = 1
 
 [id]
-version = 3.1.1
+version = 3.1.2
 name = TA_runzero_asset_sync
 
 [launcher]
 author = runZero
-version = 3.1.1
+version = 3.1.2
 description = This application synchronizes a runZero inventory with Splunk, pulling newly-found or updated hosts as configured.
 
 [ui]

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
 rm -f TA_runzero_asset_sync.tar TA_runzero_asset_sync.tar.gz *.spl
-COPYFILE_DISABLE=1 tar --exclude='.*' --exclude='.*/' -cf TA_runzero_asset_sync.tar TA_runzero_asset_sync && gzip -9 TA_runzero_asset_sync.tar && mv TA_runzero_asset_sync.tar.gz TA_runzero_asset_sync-3.1.1.spl
+COPYFILE_DISABLE=1 tar --exclude='.*' --exclude='.*/' -cf TA_runzero_asset_sync.tar TA_runzero_asset_sync && gzip -9 TA_runzero_asset_sync.tar && mv TA_runzero_asset_sync.tar.gz TA_runzero_asset_sync-3.1.2.spl


### PR DESCRIPTION
This works around a bug that can prevent editing the runZero Splunk add-on when a corrupted passwords.conf exists.

![image](https://github.com/user-attachments/assets/704077fc-2525-40c1-9fd2-832da7c0006a)


This changes code in the Splunk-authored dependency libraries.  This will need to be maintained as we upgrade these libraries.

The underlying issue, as far as we can tell, is that any add-on's `passwords.conf` file contains an invalid encrypted or empty value.  This can occur when copying add-ons from one Splunk instance to another.  You can reproduce this error by changing any encrypted value in any `passwords.conf` file.  But we are unsure how systems get into this state.

See also:
* https://community.splunk.com/t5/All-Apps-and-Add-ons/TheHive-Cortex-2-3-2-REST-Error-500/td-p/693101
* https://github.com/splunk/addonfactory-solutions-library-python/issues/311