### PR TITLE
Don't parse extractions at index-time

### DIFF
--- a/TA_runzero_asset_sync/default/props.conf
+++ b/TA_runzero_asset_sync/default/props.conf
@@ -2,7 +2,7 @@
 sourcetype = tarunzeroassetsync:log
 
 [assets]
-INDEXED_EXTRACTIONS = json
+INDEXED_EXTRACTIONS = none
 KV_MODE = json
 SHOULD_LINEMERGE = 0
 TIMESTAMP_FIELDS = _splunk_event_ts


### PR DESCRIPTION
This changes our add-on to stop extracting fields at index-time.  This is generally not recommended by Splunk and results in duplicate attributes when combined with search-time extractions.