### PR TITLE
add macro support

### DIFF
--- a/TA_runzero_asset_sync/TA_runzero_asset_sync.aob_meta
+++ b/TA_runzero_asset_sync/TA_runzero_asset_sync.aob_meta
@@ -2,7 +2,7 @@
   "basic_builder": {
     "appname": "TA_runzero_asset_sync",
     "friendly_name": "runZero Asset Sync",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "author": "runZero",
     "description": "This application synchronizes a runZero inventory with Splunk, pulling newly-found or updated hosts as configured. It also includes saved searches and out of the box dashboards to show how to use the data natively in Splunk.",
     "theme": "#008099",

--- a/TA_runzero_asset_sync/app.manifest
+++ b/TA_runzero_asset_sync/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "TA_runzero_asset_sync",
-      "version": "3.3.0"
+      "version": "3.3.1"
     },
     "author": [
       {

--- a/TA_runzero_asset_sync/appserver/static/js/build/globalConfig.json
+++ b/TA_runzero_asset_sync/appserver/static/js/build/globalConfig.json
@@ -2,7 +2,7 @@
     "meta": {
         "name": "TA_runzero_asset_sync",
         "displayName": "runZero Asset Sync",
-        "version": "3.3.0",
+        "version": "3.3.1",
         "restRoot": "TA_runzero_asset_sync",
         "schemaVersion": "0.0.8",
         "_uccVersion": "5.48.0"

--- a/TA_runzero_asset_sync/default/app.conf
+++ b/TA_runzero_asset_sync/default/app.conf
@@ -7,7 +7,7 @@ build = 2
 
 [launcher]
 author = runZero
-version = 3.3.0
+version = 3.3.1
 description = This application synchronizes a runZero inventory with Splunk, pulling newly-found or updated hosts as configured. It also includes saved searches and out of the box dashboards to show how to use the data natively in Splunk.
 
 [ui]

--- a/TA_runzero_asset_sync/default/macros.conf
+++ b/TA_runzero_asset_sync/default/macros.conf
@@ -1,0 +1,3 @@
+[runzero-index]
+definition = index=*
+iseval = 0

--- a/TA_runzero_asset_sync/default/savedsearches.conf
+++ b/TA_runzero_asset_sync/default/savedsearches.conf
@@ -1,137 +1,137 @@
 [runzero_total_unique_assets]
-search = sourcetype=assets | dedup id | stats count AS total_assets
+search = `runzero-index` sourcetype=assets | dedup id | stats count AS total_assets
 description = Total count of unique assets in the inventory.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_total_risk_score]
-search = sourcetype=assets | dedup id | stats sum(risk_rank) AS total_risk_score
+search = `runzero-index` sourcetype=assets | dedup id | stats sum(risk_rank) AS total_risk_score
 description = Total sum of risk rank across all unique assets.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_asset_count_by_risk_category]
-search = sourcetype=assets risk != "" | dedup id | stats count AS asset_count BY risk | sort 0 - asset_count
+search = `runzero-index` sourcetype=assets risk != "" | dedup id | stats count AS asset_count BY risk | sort 0 - asset_count
 description = Count of assets in each qualitative risk category (High, Medium, Low).
 enableSched = 0
 cron_schedule = 15 * * * *
 
 [runzero_risk_by_os_product]
-search = sourcetype=assets os_product != "" risk_rank != "" | dedup id | stats sum(risk_rank) AS risk_score BY os_product | sort 0 - risk_score | head 10
+search = `runzero-index` sourcetype=assets os_product != "" risk_rank != "" | dedup id | stats sum(risk_rank) AS risk_score BY os_product | sort 0 - risk_score | head 10
 description = Top 10 OS Products by summed risk score.
 enableSched = 0
 cron_schedule = 30 * * * *
 
 [runzero_asset_count_by_type]
-search = sourcetype=assets type != "" | dedup id | stats count AS asset_count BY type | sort 0 - asset_count
+search = `runzero-index` sourcetype=assets type != "" | dedup id | stats count AS asset_count BY type | sort 0 - asset_count
 description = Count of assets grouped by their defined type (Server, Workstation, etc.).
 enableSched = 0
 cron_schedule = 45 * * * *
 
 [runzero_assets_by_site]
-search = sourcetype=assets site_name != "" | dedup id | stats count AS asset_count BY site_name | sort 0 - asset_count
+search = `runzero-index` sourcetype=assets site_name != "" | dedup id | stats count AS asset_count BY site_name | sort 0 - asset_count
 description = Count of assets grouped by site location.
 enableSched = 0
 cron_schedule = 50 * * * *
 
 [runzero_os_version_distribution]
-search = sourcetype=assets os_product != "" os_version != "" | dedup id | chart count AS Count over os_product by os_version | sort - Count
+search = `runzero-index` sourcetype=assets os_product != "" os_version != "" | dedup id | chart count AS Count over os_product by os_version | sort - Count
 description = Top 10 common combinations of OS Product and Version.
 enableSched = 0
 cron_schedule = 20 * * * *
 
 [runzero_assets_by_criticality]
-search = sourcetype=assets criticality != "" | dedup id | stats count AS asset_count BY criticality | sort 0 - asset_count
+search = `runzero-index` sourcetype=assets criticality != "" | dedup id | stats count AS asset_count BY criticality | sort 0 - asset_count
 description = Count of assets grouped by their criticality level.
 enableSched = 0
 cron_schedule = 25 * * * *
 
 [runzero_new_assets_last_24_hours]
-search = sourcetype=assets earliest=-1d | dedup id | sort 0 - updated_at | table host, dvc_ip, os_product, asset_updated
+search = `runzero-index` sourcetype=assets earliest=-1d | dedup id | sort 0 - updated_at | table host, dvc_ip, os_product, asset_updated
 description = Table of new assets created in the last 24 hours.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_asset_vendors_distribution]
-search = sourcetype=assets hw_vendor != "" | dedup id | stats count by hw_vendor | sort - count | head 10
+search = `runzero-index` sourcetype=assets hw_vendor != "" | dedup id | stats count by hw_vendor | sort - count | head 10
 description = Distribution of asset hardware vendors.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_critical_vulnerability_trend]
-search = sourcetype=assets risk="critical" | timechart span=1d count as critical_vulns
+search = `runzero-index` sourcetype=assets risk="critical" | timechart span=1d count as critical_vulns
 description = Trend of critical vulnerabilities over time.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_top_10_high_risk_assets]
-search = sourcetype=assets | dedup id | sort - risk_rank | head 10 | table host, dvc_ip, risk_rank
+search = `runzero-index` sourcetype=assets | dedup id | sort - risk_rank | head 10 | table host, dvc_ip, risk_rank
 description = Top 10 assets with the highest risk scores.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_vulnerability_severity_distribution]
-search = sourcetype=assets risk != "" | stats count by risk | sort - count
+search = `runzero-index` sourcetype=assets risk != "" | stats count by risk | sort - count
 description = Distribution of vulnerability severities.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_top_service_products]
-search = sourcetype=assets | rename "service_products{}" AS service_products | eval service_products = split(mvjoin(service_products, " "), " ") | mvexpand service_products | where service_products != "" AND isnotnull(service_products) | top limit=20 service_products
+search = `runzero-index` sourcetype=assets | rename "service_products{}" AS service_products | eval service_products = split(mvjoin(service_products, " "), " ") | mvexpand service_products | where service_products != "" AND isnotnull(service_products) | top limit=20 service_products
 description = Top service products split by space.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_vulnerability_stats]
-search = sourcetype=assets | stats avg(vulnerability_count) as avg_vulns, max(vulnerability_count) as max_vulns, min(vulnerability_count) as min_vulns
+search = `runzero-index` sourcetype=assets | stats avg(vulnerability_count) as avg_vulns, max(vulnerability_count) as max_vulns, min(vulnerability_count) as min_vulns
 description = Vulnerability count statistics.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_outlier_score_distribution]
-search = sourcetype=assets | stats count by outlier_score
+search = `runzero-index` sourcetype=assets | stats count by outlier_score
 description = Outlier score distribution.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_rare_hardware]
-search = sourcetype=assets | rare limit=20 hw
+search = `runzero-index` sourcetype=assets | rare limit=20 hw
 description = Rare hardware types found in inventory.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_avg_service_count]
-search = sourcetype=assets | stats avg(service_count) as avg_services
+search = `runzero-index` sourcetype=assets | stats avg(service_count) as avg_services
 description = Average service count per asset.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_avg_udp_service_count]
-search = sourcetype=assets | stats avg(service_count_udp) as avg_udp_services
+search = `runzero-index` sourcetype=assets | stats avg(service_count_udp) as avg_udp_services
 description = Average UDP service count per asset.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_top_tcp_ports]
-search = sourcetype=assets | mvexpand service_ports_tcp | top limit=20 service_ports_tcp
+search = `runzero-index` sourcetype=assets | mvexpand service_ports_tcp | top limit=20 service_ports_tcp
 description = Top TCP ports across the environment.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_avg_software_count]
-search = sourcetype=assets | stats avg(software_count) as avg_software
+search = `runzero-index` sourcetype=assets | stats avg(software_count) as avg_software
 description = Average software product count per asset.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_assets_by_owner]
-search = sourcetype=assets | mvexpand "ownership{}.name" | top "ownership{}.name"
+search = `runzero-index` sourcetype=assets | mvexpand "ownership{}.name" | top "ownership{}.name"
 description = Assets grouped by owner name.
 enableSched = 0
 cron_schedule = 0 * * * *
 
 [runzero_assets_by_source_id]
-search = sourcetype=assets | mvexpand "source_ids{}" | eval source_name=case('source_ids{}'==-1, "Custom", 'source_ids{}'=1, "runZero", 'source_ids{}'=10, "Tenable", 'source_ids{}'=11, "Nessus", 'source_ids{}'=12, "Rapid7", 'source_ids{}'=13, "InsightVM", 'source_ids{}'=14, "Qualys", 'source_ids{}'=15, "Shodan", 'source_ids{}'=16, "AzureAD", 'source_ids{}'=17, "LDAP", 'source_ids{}'=18, "MS365Defender", 'source_ids{}'=19, "Intune", 'source_ids{}'=2, "Miradore", 'source_ids{}'=20, "GoogleWorkspace", 'source_ids{}'=21, "Sample", 'source_ids{}'=22, "TenableSecurityCenter", 'source_ids{}'=23, "Packet", 'source_ids{}'=24, "Wiz", 'source_ids{}'=25, "Meraki", 'source_ids{}'=26, "MECM", 'source_ids{}'=27, "Tanium", 'source_ids{}'=28, "Simulator", 'source_ids{}'=29, "NetBox", 'source_ids{}'=3, "AWS", 'source_ids{}'=30, "CIP", 'source_ids{}'=31, "Palo Alto Networks", 'source_ids{}'=32, "Prisma", 'source_ids{}'=34, "Dragos", 'source_ids{}'=4, "CrowdStrike", 'source_ids{}'=5, "Azure", 'source_ids{}'=6, "Censys", 'source_ids{}'=7, "VMware", 'source_ids{}'=8, "GCP", 'source_ids{}'=9, "SentinelOne", true(), "UNKNOWN") | top source_name
+search = `runzero-index` sourcetype=assets | mvexpand "source_ids{}" | eval source_name=case('source_ids{}'==-1, "Custom", 'source_ids{}'=1, "runZero", 'source_ids{}'=10, "Tenable", 'source_ids{}'=11, "Nessus", 'source_ids{}'=12, "Rapid7", 'source_ids{}'=13, "InsightVM", 'source_ids{}'=14, "Qualys", 'source_ids{}'=15, "Shodan", 'source_ids{}'=16, "AzureAD", 'source_ids{}'=17, "LDAP", 'source_ids{}'=18, "MS365Defender", 'source_ids{}'=19, "Intune", 'source_ids{}'=2, "Miradore", 'source_ids{}'=20, "GoogleWorkspace", 'source_ids{}'=21, "Sample", 'source_ids{}'=22, "TenableSecurityCenter", 'source_ids{}'=23, "Packet", 'source_ids{}'=24, "Wiz", 'source_ids{}'=25, "Meraki", 'source_ids{}'=26, "MECM", 'source_ids{}'=27, "Tanium", 'source_ids{}'=28, "Simulator", 'source_ids{}'=29, "NetBox", 'source_ids{}'=3, "AWS", 'source_ids{}'=30, "CIP", 'source_ids{}'=31, "Palo Alto Networks", 'source_ids{}'=32, "Prisma", 'source_ids{}'=34, "Dragos", 'source_ids{}'=4, "CrowdStrike", 'source_ids{}'=5, "Azure", 'source_ids{}'=6, "Censys", 'source_ids{}'=7, "VMware", 'source_ids{}'=8, "GCP", 'source_ids{}'=9, "SentinelOne", true(), "UNKNOWN") | top source_name
 description = Assets breakdown by ingestion source.
 enableSched = 0
 cron_schedule = 0 * * * *

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
 rm -f TA_runzero_asset_sync.tar TA_runzero_asset_sync.tar.gz *.spl
-COPYFILE_DISABLE=1 tar --exclude='.*' --exclude='.*/' -cf TA_runzero_asset_sync.tar TA_runzero_asset_sync && gzip -9 TA_runzero_asset_sync.tar && mv TA_runzero_asset_sync.tar.gz TA_runzero_asset_sync-3.3.0.spl
+COPYFILE_DISABLE=1 tar --exclude='.*' --exclude='.*/' -cf TA_runzero_asset_sync.tar TA_runzero_asset_sync && gzip -9 TA_runzero_asset_sync.tar && mv TA_runzero_asset_sync.tar.gz TA_runzero_asset_sync-3.3.1.spl


### PR DESCRIPTION
Resolves https://github.com/runZeroInc/platform/issues/23045

This update does 2 things:

1. Creates a `runzero-index` macro that prepends `index=*` to all the saved searches (by default) 
2. Allows the user to update the `runzero-index` to whatever makes sense based on how they configured the app

<img width="1376" height="733" alt="Screenshot 2026-01-05 at 11 48 16 AM" src="https://github.com/user-attachments/assets/4ea1de0e-08ae-4568-84d6-50a57e23d021" />
<img width="1378" height="729" alt="Screenshot 2026-01-05 at 11 48 09 AM" src="https://github.com/user-attachments/assets/12b8c4ea-f2f5-4feb-9459-0828c0f96a16" />
<img width="1202" height="624" alt="Screenshot 2026-01-05 at 11 47 49 AM" src="https://github.com/user-attachments/assets/1255c800-2ffc-4c1e-b256-5848683338aa" />

