### PR TITLE
set required python version to 3.13, bump app version

### DIFF
--- a/TA_runzero_asset_sync/TA_runzero_asset_sync.aob_meta
+++ b/TA_runzero_asset_sync/TA_runzero_asset_sync.aob_meta
@@ -2,7 +2,7 @@
   "basic_builder": {
     "appname": "TA_runzero_asset_sync",
     "friendly_name": "runZero Asset Sync",
-    "version": "3.3.2",
+    "version": "3.3.3",
     "author": "runZero",
     "description": "This application synchronizes a runZero inventory with Splunk, pulling newly-found or updated hosts as configured. It also includes saved searches and out of the box dashboards to show how to use the data natively in Splunk.",
     "theme": "#008099",

--- a/TA_runzero_asset_sync/app.manifest
+++ b/TA_runzero_asset_sync/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "TA_runzero_asset_sync",
-      "version": "3.3.2"
+      "version": "3.3.3"
     },
     "author": [
       {

--- a/TA_runzero_asset_sync/appserver/static/js/build/globalConfig.json
+++ b/TA_runzero_asset_sync/appserver/static/js/build/globalConfig.json
@@ -2,7 +2,7 @@
     "meta": {
         "name": "TA_runzero_asset_sync",
         "displayName": "runZero Asset Sync",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "restRoot": "TA_runzero_asset_sync",
         "schemaVersion": "0.0.8",
         "_uccVersion": "5.48.0"

--- a/TA_runzero_asset_sync/default/app.conf
+++ b/TA_runzero_asset_sync/default/app.conf
@@ -7,7 +7,7 @@ build = 2
 
 [launcher]
 author = runZero
-version = 3.3.2
+version = 3.3.3
 description = This application synchronizes a runZero inventory with Splunk, pulling newly-found or updated hosts as configured. It also includes saved searches and out of the box dashboards to show how to use the data natively in Splunk.
 
 [ui]

--- a/TA_runzero_asset_sync/default/inputs.conf
+++ b/TA_runzero_asset_sync/default/inputs.conf
@@ -1,6 +1,7 @@
 [assets]
 start_by_shell = false
 python.version = python3
+python.required = 3.13
 sourcetype = assets
 interval = 3600
 sync_type = created

--- a/TA_runzero_asset_sync/default/restmap.conf
+++ b/TA_runzero_asset_sync/default/restmap.conf
@@ -6,6 +6,7 @@ members = TA_runzero_asset_sync_account, TA_runzero_asset_sync_settings, TA_runz
 [admin_external:TA_runzero_asset_sync_account]
 handlertype = python
 python.version = python3
+python.required = 3.13
 handlerfile = TA_runzero_asset_sync_rh_account.py
 handleractions = edit, list, remove, create
 handlerpersistentmode = true
@@ -13,6 +14,7 @@ handlerpersistentmode = true
 [admin_external:TA_runzero_asset_sync_settings]
 handlertype = python
 python.version = python3
+python.required = 3.13
 handlerfile = TA_runzero_asset_sync_rh_settings.py
 handleractions = edit, list
 handlerpersistentmode = true
@@ -20,6 +22,7 @@ handlerpersistentmode = true
 [admin_external:TA_runzero_asset_sync_assets]
 handlertype = python
 python.version = python3
+python.required = 3.13
 handlerfile = TA_runzero_asset_sync_rh_assets.py
 handleractions = edit, list, remove, create
 handlerpersistentmode = true

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
 rm -f TA_runzero_asset_sync.tar TA_runzero_asset_sync.tar.gz *.spl
-COPYFILE_DISABLE=1 tar --exclude='.*' --exclude='.*/' -cf TA_runzero_asset_sync.tar TA_runzero_asset_sync && gzip -9 TA_runzero_asset_sync.tar && mv TA_runzero_asset_sync.tar.gz TA_runzero_asset_sync-3.3.2.spl
+COPYFILE_DISABLE=1 tar --exclude='.*' --exclude='.*/' -cf TA_runzero_asset_sync.tar TA_runzero_asset_sync && gzip -9 TA_runzero_asset_sync.tar && mv TA_runzero_asset_sync.tar.gz TA_runzero_asset_sync-3.3.3.spl


### PR DESCRIPTION
Sets `python.required` to 3.13 to reflect deprecation of Python 3.9 in Splunk.